### PR TITLE
Stop ignoring the env while php-cs-fixer is run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ test-min: update-min cs deptrac phpunit infection
 .PHONY: test-min
 
 cs: tools/php-cs-fixer
-	PHP_CS_FIXER_IGNORE_ENV=1 tools/php-cs-fixer --dry-run --allow-risky=yes --no-interaction --ansi fix
+	tools/php-cs-fixer --dry-run --allow-risky=yes --no-interaction --ansi fix
 .PHONY: cs
 
 cs-fix: tools/php-cs-fixer
-	PHP_CS_FIXER_IGNORE_ENV=1 tools/php-cs-fixer --allow-risky=yes --no-interaction --ansi fix
+	tools/php-cs-fixer --allow-risky=yes --no-interaction --ansi fix
 .PHONY: cs-fix
 
 deptrac: tools/deptrac


### PR DESCRIPTION
Fixes #9 