### PR TITLE
Fix one-line inject annotation

### DIFF
--- a/src/Reflection/ReflectionExtractor.php
+++ b/src/Reflection/ReflectionExtractor.php
@@ -61,7 +61,7 @@ final class ReflectionExtractor implements Extractor
 
     private function extractServiceId(\ReflectionProperty $property): string
     {
-        if (1 === \preg_match('#\s*\**\s*\@inject (?P<serviceId>[^\s]+)#', $property->getDocComment(), $matches)) {
+        if (1 === \preg_match('#\s*\**\s*\@inject (?P<serviceId>[^\s*]+)#', $property->getDocComment(), $matches)) {
             return $matches['serviceId'];
         } elseif ($property->getType() instanceof \ReflectionType) {
             return $property->getType()->getName();

--- a/tests/Reflection/Fixtures/FieldInjectionExample.php
+++ b/tests/Reflection/Fixtures/FieldInjectionExample.php
@@ -25,4 +25,7 @@ class FieldInjectionExample
     private Foo $fieldWithNoInject;
 
     private $fieldWithNoDocBlock;
+
+    /** @inject */
+    private Foo $fieldWithTypeNoServiceIdOneLine;
 }

--- a/tests/Reflection/Fixtures/FieldsTrait.php
+++ b/tests/Reflection/Fixtures/FieldsTrait.php
@@ -25,4 +25,7 @@ trait FieldsTrait
     private Foo $fieldWithNoInject;
 
     private $fieldWithNoDocBlock;
+
+    /** @inject */
+    private Foo $fieldWithTypeNoServiceIdOneLine;
 }

--- a/tests/Reflection/ReflectionExtractorTest.php
+++ b/tests/Reflection/ReflectionExtractorTest.php
@@ -42,10 +42,11 @@ class ReflectionExtractorTest extends TestCase
         $serviceProperties = $this->servicePropertyExtractor->extract(FieldInjectionExample::class);
 
         $this->assertContainsOnlyInstancesOf(Property::class, $serviceProperties);
-        $this->assertCount(3, $serviceProperties);
+        $this->assertCount(4, $serviceProperties);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithServiceIdNoType', 'foo.bar'), $serviceProperties[0]);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeNoServiceId', Foo::class), $serviceProperties[1]);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeAndServiceId', 'foo.bar'), $serviceProperties[2]);
+        $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeNoServiceIdOneLine', Foo::class), $serviceProperties[3]);
     }
 
     public function test_it_extracts_service_definitions_from_trait_properties()
@@ -53,10 +54,11 @@ class ReflectionExtractorTest extends TestCase
         $serviceProperties = $this->servicePropertyExtractor->extract(FieldsImportedWithTraitExample::class);
 
         $this->assertContainsOnlyInstancesOf(Property::class, $serviceProperties);
-        $this->assertCount(3, $serviceProperties);
+        $this->assertCount(4, $serviceProperties);
         $this->assertEquals(new Property(FieldsImportedWithTraitExample::class, 'fieldWithServiceIdNoType', 'foo.bar'), $serviceProperties[0]);
         $this->assertEquals(new Property(FieldsImportedWithTraitExample::class, 'fieldWithTypeNoServiceId', Foo::class), $serviceProperties[1]);
         $this->assertEquals(new Property(FieldsImportedWithTraitExample::class, 'fieldWithTypeAndServiceId', 'foo.bar'), $serviceProperties[2]);
+        $this->assertEquals(new Property(FieldsImportedWithTraitExample::class, 'fieldWithTypeNoServiceIdOneLine', Foo::class), $serviceProperties[3]);
     }
 
     public function test_it_ignores_a_duplicated_inject()
@@ -81,10 +83,11 @@ class ReflectionExtractorTest extends TestCase
         $serviceProperties = $this->servicePropertyExtractor->extract(ChildInjectionExample::class);
 
         $this->assertContainsOnlyInstancesOf(Property::class, $serviceProperties);
-        $this->assertCount(3, $serviceProperties);
+        $this->assertCount(4, $serviceProperties);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithServiceIdNoType', 'foo.bar'), $serviceProperties[0]);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeNoServiceId', Foo::class), $serviceProperties[1]);
         $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeAndServiceId', 'foo.bar'), $serviceProperties[2]);
+        $this->assertEquals(new Property(FieldInjectionExample::class, 'fieldWithTypeNoServiceIdOneLine', Foo::class), $serviceProperties[3]);
     }
 
     public function test_it_does_not_extract_properties_from_ignored_classes()


### PR DESCRIPTION
Hi, the docBlock parsing was not working in case the `@inject` annotation is put on one line and has no service id.

```php
/** @inject */
private Foo $fooFields;
```

This would evaluate to service named `*/` which would obviously fail.

The change modifies the regexp to not match these one-liners. I also extended unit tests to cover this case.